### PR TITLE
Fix string deprecations

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -3,6 +3,11 @@ import Ember from "ember";
 var get = Ember.get;
 var run = Ember.run;
 
+// Simple fmt implementation since Ember.String.fmt is deprecated
+function fmt(str, token) {
+  return str.replace('%@', token);
+}
+
 /**
  * Ember select-2 component wrapping the jQuery select2 plugin while
  * respecting Ember data bindings and getter/setter methods on the content.
@@ -246,7 +251,7 @@ var Select2Component = Ember.Component.extend({
 
       term = Ember.Handlebars.Utils.escapeExpression(term);
 
-      return Ember.String.htmlSafe(Ember.String.fmt(text, term));
+      return Ember.String.htmlSafe(fmt(text, term));
     };
 
     /*
@@ -256,7 +261,7 @@ var Select2Component = Ember.Component.extend({
     options.formatAjaxError = function(jqXHR, textStatus, errorThrown) {
       var text = self.get('typeaheadErrorText');
 
-      return Ember.String.htmlSafe(Ember.String.fmt(text, errorThrown));
+      return Ember.String.htmlSafe(fmt(text, errorThrown));
     };
 
     /*

--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -245,7 +245,7 @@ var Select2Component = Ember.Component.extend({
      */
     options.formatNoMatches = function(term) {
       var text = self.get('typeaheadNoMatchesText');
-      if (text instanceof Ember.Handlebars.SafeString) {
+      if (Ember.String.isHTMLSafe(text)) {
         text = text.string;
       }
 


### PR DESCRIPTION
Fix `Ember.String.fmt` and `Ember.Handlebars.SafeString` deprecations.